### PR TITLE
feat : add storage diff rpc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15443,6 +15443,7 @@ dependencies = [
  "assert_matches",
  "env_logger 0.9.3",
  "futures",
+ "itertools 0.11.0",
  "jsonrpsee",
  "log",
  "parity-scale-codec",

--- a/substrate/client/rpc-api/src/state/mod.rs
+++ b/substrate/client/rpc-api/src/state/mod.rs
@@ -66,6 +66,10 @@ pub trait StateApi<Hash> {
 	#[method(name = "state_getStorage", aliases = ["state_getStorageAt"], blocking)]
 	fn storage(&self, key: StorageKey, hash: Option<Hash>) -> RpcResult<Option<StorageData>>;
 
+	/// Returns a storage entry at a specific block's state.
+	#[method(name = "state_getStorageDiff", aliases = ["state_getStorageDiffAt"], blocking)]
+	fn storage_diff(&self, start: Hash, end: Hash) -> RpcResult<Vec<(StorageKey, Option<StorageData>)>>;
+
 	/// Returns the hash of a storage entry at a block's state.
 	#[method(name = "state_getStorageHash", aliases = ["state_getStorageHashAt"], blocking)]
 	fn storage_hash(&self, key: StorageKey, hash: Option<Hash>) -> RpcResult<Option<Hash>>;

--- a/substrate/client/rpc-api/src/state/mod.rs
+++ b/substrate/client/rpc-api/src/state/mod.rs
@@ -66,7 +66,7 @@ pub trait StateApi<Hash> {
 	#[method(name = "state_getStorage", aliases = ["state_getStorageAt"], blocking)]
 	fn storage(&self, key: StorageKey, hash: Option<Hash>) -> RpcResult<Option<StorageData>>;
 
-	/// Returns a storage entry at a specific block's state.
+	/// Returns a storage diff between start block state and end block state
 	#[method(name = "state_getStorageDiff", aliases = ["state_getStorageDiffAt"], blocking)]
 	fn storage_diff(&self, start: Hash, end: Hash) -> RpcResult<Vec<(StorageKey, Option<StorageData>)>>;
 

--- a/substrate/client/rpc/Cargo.toml
+++ b/substrate/client/rpc/Cargo.toml
@@ -17,6 +17,7 @@ codec = { package = "parity-scale-codec", version = "3.6.1" }
 futures = "0.3.21"
 jsonrpsee = { version = "0.16.2", features = ["server"] }
 log = "0.4.17"
+itertools = "0.11.0"
 parking_lot = "0.12.1"
 serde_json = "1.0.107"
 sc-block-builder = { path = "../block-builder" }

--- a/substrate/client/rpc/src/state/mod.rs
+++ b/substrate/client/rpc/src/state/mod.rs
@@ -98,6 +98,13 @@ where
 		key: StorageKey,
 	) -> Result<Option<StorageData>, Error>;
 
+	/// Returns a storage diff between start block and end block
+	fn storage_diff(
+		&self,
+		start: Block::Hash,
+		end: Block::Hash,
+	) -> RpcResult<Vec<(StorageKey, Option<StorageData>)>>;
+
 	/// Returns the hash of a storage entry at a block's state.
 	fn storage_hash(
 		&self,
@@ -252,6 +259,14 @@ where
 		block: Option<Block::Hash>,
 	) -> RpcResult<Option<StorageData>> {
 		self.backend.storage(block, key).map_err(Into::into)
+	}
+
+	fn storage_diff(
+		&self,
+		start: Block::Hash,
+		end: Block::Hash,
+	) -> RpcResult<Vec<(StorageKey, Option<StorageData>)>> {
+		self.backend.storage_diff(start, end).map_err(Into::into)
 	}
 
 	fn storage_hash(

--- a/substrate/client/rpc/src/state/state_full.rs
+++ b/substrate/client/rpc/src/state/state_full.rs
@@ -19,14 +19,13 @@
 //! State API backend for full nodes.
 
 use std::{collections::HashMap, marker::PhantomData, sync::Arc, time::Duration};
-
 use super::{
 	client_err,
 	error::{Error, Result},
 	ChildStateBackend, StateBackend,
 };
 use crate::{DenyUnsafe, SubscriptionTaskExecutor};
-
+use itertools::Itertools;
 use futures::{future, stream, FutureExt, StreamExt};
 use jsonrpsee::{
 	core::{async_trait, Error as JsonRpseeError},
@@ -215,6 +214,35 @@ where
 			.and_then(|block| self.client.storage_keys(block, Some(&prefix), None))
 			.map(|iter| iter.collect())
 			.map_err(client_err)
+	}
+
+	fn storage_diff(
+		&self,
+		start : Block::Hash,
+		end : Block::Hash,
+	) -> std::result::Result<Vec<(StorageKey, Option<StorageData>)>, JsonRpseeError> {
+		let mut start_keys = self.client.storage_keys(start, None, None).map_err(client_err)?;
+		let end_keys = self.client.storage_keys(end, None, None).map_err(client_err)?;
+		
+		// prepare diff
+		let mut storage_diff : Vec<(StorageKey, Option<StorageData>)> = vec![];
+		for key in end_keys {
+			// if a new key is present, add it to the diff
+			if !start_keys.contains(&key) {
+				let new_storage = self.client.storage(end, &key).map_err(client_err)?;
+				storage_diff.push((key, new_storage))
+			} else {
+				let start_storage_val = self.client.storage(start, &key).map_err(client_err)?;
+				let end_storage_val = self.client.storage(end, &key).map_err(client_err)?;
+
+				if start_storage_val != end_storage_val {
+					storage_diff.push((key, end_storage_val))
+				}
+			}
+		}
+
+		Ok(storage_diff)
+
 	}
 
 	// TODO: This is horribly broken; either remove it, or make it streaming.

--- a/substrate/client/rpc/src/state/state_full.rs
+++ b/substrate/client/rpc/src/state/state_full.rs
@@ -241,6 +241,13 @@ where
 			}
 		}
 
+		// finally get any keys that have been removed between start_block and end_block
+		for key in start_keys {
+			if storage_diff.iter().position(|r| r.0 == key).is_none() {
+				storage_diff.push((key, None))
+			}
+		}
+
 		Ok(storage_diff)
 
 	}


### PR DESCRIPTION
RPC to return changes in storage between two blocks,

Example : 
`curl -sS -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method": "state_getStorageDiff", "params": ["0xaa254e5ff33843f4abfb2527c7273239f395f7f7da10b6018646f4ae7257f913", "0xb2990969fd7771959f534d3d985603b5632fb6a3faf628d7ba79c564424de7ae"]}' http://localhost:9944/`

Result : 
```
{"jsonrpc":"2.0","result":[["0x26aa394eea5630e07c48ae0c9558cef702a5c1b19ab7a04f536c519aca4983ac","0x33000000"],["0x26aa394eea5630e07c48ae0c9558cef78a42f33323cb5ced3b44dd825fda9fcc","0xda6e43000582e224d717d60d1fa65ef7bc5b05ccb4ff412c67f8d334a86c8cbd"],["0x26aa394eea5630e07c48ae0c9558cef799e7f93fc6a98f0874fd057f111c4d2d","0x04066175726120baf1d91000000000"],["0x26aa394eea5630e07c48ae0c9558cef7a44704b568d21667356a5a050c1187468e233f9722d30ebf31000000","0xaa254e5ff33843f4abfb2527c7273239f395f7f7da10b6018646f4ae7257f913"],["0x26aa394eea5630e07c48ae0c9558cef7a44704b568d21667356a5a050c118746926f3965faf45f0f16000000","0x403edf6b6b63e8f0402b4815ef63efd29628e29e92c9931012d7470b7730cd0c"],["0x26aa394eea5630e07c48ae0c9558cef7a44704b568d21667356a5a050c1187469d7a9a93920005ae1d000000","0xe7cd5c4f22a46446a36066dffb9c303ceb8d00c2d0a421c56d6ee1b5daf86593"],["0x26aa394eea5630e07c48ae0c9558cef7a44704b568d21667356a5a050c1187469eb2dcce60f37a2702000000","0x75d57415c5640f1c184a9424e01b4979a74f0b6f19a6e41bee3df52eb3b8d4a3"],["0x26aa394eea5630e07c48ae0c9558cef7a44704b568d21667356a5a050c118746a6b274250e6753f00a000000","0xfdd294deb2e99978a9a24eb8eee81de72d839f6c27588ba255e29050e9799cff"],....
```

**Performance when tested :**

**Env** : Substrate node template runtime
**Tested using** : `curl -sS -s -w 'Establish Connection: %{time_connect}s\nTTFB: %{time_starttransfer}s\nTotal: %{time_total}s\n' -H "Content-Ty....`
**Result** :
```
Establish Connection: 0.006368s
TTFB: 0.024987s
Total: 0.040980s
```