### PR TITLE
Add storage_diff rpc that allows setting included and excluded prefixes

### DIFF
--- a/substrate/client/rpc-api/src/state/mod.rs
+++ b/substrate/client/rpc-api/src/state/mod.rs
@@ -70,13 +70,9 @@ pub trait StateApi<Hash> {
 	#[method(name = "state_getStorageDiff", aliases = ["state_getStorageDiffAt"], blocking)]
 	fn storage_diff(&self, start: Hash, end: Hash) -> RpcResult<Vec<(StorageKey, Option<StorageData>)>>;
 
-	/// Returns a storage diff between start block state and end block state of the given keys
+	/// Returns a storage diff between start block state and end block state with option to include or exclude prefixes
 	#[method(name = "state_getStorageDiffWithPrefixes", aliases = ["state_getStorageDiffPrefixes"], blocking)]
-	fn storage_diff_with_prefixes(&self, start: Hash, end: Hash, prefixes : Vec<StorageKey>) -> RpcResult<Vec<(StorageKey, Option<StorageData>)>>;
-
-	/// Returns a storage diff between start block state and end block state of all the keys except given prefixes
-	#[method(name = "state_getStorageDiffWithoutPrefixes", aliases = ["state_getStorageDiffWOPrefixes"], blocking)]
-	fn storage_diff_without_prefixes(&self, start: Hash, end: Hash, prefixes : Vec<StorageKey>) -> RpcResult<Vec<(StorageKey, Option<StorageData>)>>;
+	fn storage_diff_with_prefixes(&self, start: Hash, end: Hash, include_prefixes : Option<Vec<StorageKey>>, exclude_prefixes : Option<Vec<StorageKey>>) -> RpcResult<Vec<(StorageKey, Option<StorageData>)>>;
 	
 	/// Returns the hash of a storage entry at a block's state.
 	#[method(name = "state_getStorageHash", aliases = ["state_getStorageHashAt"], blocking)]

--- a/substrate/client/rpc-api/src/state/mod.rs
+++ b/substrate/client/rpc-api/src/state/mod.rs
@@ -70,6 +70,14 @@ pub trait StateApi<Hash> {
 	#[method(name = "state_getStorageDiff", aliases = ["state_getStorageDiffAt"], blocking)]
 	fn storage_diff(&self, start: Hash, end: Hash) -> RpcResult<Vec<(StorageKey, Option<StorageData>)>>;
 
+	/// Returns a storage diff between start block state and end block state of the given keys
+	#[method(name = "state_getStorageDiffWithPrefixes", aliases = ["state_getStorageDiffPrefixes"], blocking)]
+	fn storage_diff_with_prefixes(&self, start: Hash, end: Hash, prefixes : Vec<StorageKey>) -> RpcResult<Vec<(StorageKey, Option<StorageData>)>>;
+
+	/// Returns a storage diff between start block state and end block state of all the keys except given prefixes
+	#[method(name = "state_getStorageDiffWithoutPrefixes", aliases = ["state_getStorageDiffWOPrefixes"], blocking)]
+	fn storage_diff_without_prefixes(&self, start: Hash, end: Hash, prefixes : Vec<StorageKey>) -> RpcResult<Vec<(StorageKey, Option<StorageData>)>>;
+	
 	/// Returns the hash of a storage entry at a block's state.
 	#[method(name = "state_getStorageHash", aliases = ["state_getStorageHashAt"], blocking)]
 	fn storage_hash(&self, key: StorageKey, hash: Option<Hash>) -> RpcResult<Option<Hash>>;

--- a/substrate/client/rpc/src/state/mod.rs
+++ b/substrate/client/rpc/src/state/mod.rs
@@ -105,20 +105,13 @@ where
 		end: Block::Hash,
 	) -> RpcResult<Vec<(StorageKey, Option<StorageData>)>>;
 
-	/// Returns a storage diff between start block and end block of the given prefixes
+	/// Returns a storage diff between start block and end block with an option to include or exclude prefixes
 	fn storage_diff_with_prefixes(
 		&self,
 		start: Block::Hash,
 		end: Block::Hash,
-		prefixes : Vec<StorageKey>
-	) -> RpcResult<Vec<(StorageKey, Option<StorageData>)>>;
-
-	/// Returns a storage diff between start block and end block of all keys except given prefixes
-	fn storage_diff_without_prefixes(
-		&self,
-		start: Block::Hash,
-		end: Block::Hash,
-		prefixes : Vec<StorageKey>
+		include_prefixes : Option<Vec<StorageKey>>,
+		exclude_prefixes : Option<Vec<StorageKey>>
 	) -> RpcResult<Vec<(StorageKey, Option<StorageData>)>>;
 
 	/// Returns the hash of a storage entry at a block's state.
@@ -289,18 +282,10 @@ where
 		&self,
 		start: Block::Hash,
 		end: Block::Hash,
-		prefixes : Vec<StorageKey>
+		include_prefixes : Option<Vec<StorageKey>>,
+		exclude_prefixes : Option<Vec<StorageKey>>
 	) -> RpcResult<Vec<(StorageKey, Option<StorageData>)>> {
-		self.backend.storage_diff_with_prefixes(start, end, prefixes).map_err(Into::into)
-	}
-
-	fn storage_diff_without_prefixes(
-		&self,
-		start: Block::Hash,
-		end: Block::Hash,
-		prefixes : Vec<StorageKey>
-	) -> RpcResult<Vec<(StorageKey, Option<StorageData>)>> {
-		self.backend.storage_diff_without_prefixes(start, end, prefixes).map_err(Into::into)
+		self.backend.storage_diff_with_prefixes(start, end, include_prefixes, exclude_prefixes).map_err(Into::into)
 	}
 
 	fn storage_hash(

--- a/substrate/client/rpc/src/state/mod.rs
+++ b/substrate/client/rpc/src/state/mod.rs
@@ -105,6 +105,22 @@ where
 		end: Block::Hash,
 	) -> RpcResult<Vec<(StorageKey, Option<StorageData>)>>;
 
+	/// Returns a storage diff between start block and end block of the given prefixes
+	fn storage_diff_with_prefixes(
+		&self,
+		start: Block::Hash,
+		end: Block::Hash,
+		prefixes : Vec<StorageKey>
+	) -> RpcResult<Vec<(StorageKey, Option<StorageData>)>>;
+
+	/// Returns a storage diff between start block and end block of all keys except given prefixes
+	fn storage_diff_without_prefixes(
+		&self,
+		start: Block::Hash,
+		end: Block::Hash,
+		prefixes : Vec<StorageKey>
+	) -> RpcResult<Vec<(StorageKey, Option<StorageData>)>>;
+
 	/// Returns the hash of a storage entry at a block's state.
 	fn storage_hash(
 		&self,
@@ -267,6 +283,24 @@ where
 		end: Block::Hash,
 	) -> RpcResult<Vec<(StorageKey, Option<StorageData>)>> {
 		self.backend.storage_diff(start, end).map_err(Into::into)
+	}
+
+	fn storage_diff_with_prefixes(
+		&self,
+		start: Block::Hash,
+		end: Block::Hash,
+		prefixes : Vec<StorageKey>
+	) -> RpcResult<Vec<(StorageKey, Option<StorageData>)>> {
+		self.backend.storage_diff_with_prefixes(start, end, prefixes).map_err(Into::into)
+	}
+
+	fn storage_diff_without_prefixes(
+		&self,
+		start: Block::Hash,
+		end: Block::Hash,
+		prefixes : Vec<StorageKey>
+	) -> RpcResult<Vec<(StorageKey, Option<StorageData>)>> {
+		self.backend.storage_diff_without_prefixes(start, end, prefixes).map_err(Into::into)
 	}
 
 	fn storage_hash(

--- a/substrate/client/rpc/src/state/state_full.rs
+++ b/substrate/client/rpc/src/state/state_full.rs
@@ -200,35 +200,35 @@ where
 		Ok(storage_diff)
 	}
 
-		/// Helper function to check a key against lists of prefixes
-		fn is_target_key(
-			&self,
-			key_to_check: StorageKey,
-			include_prefixes : Option<Vec<StorageKey>>,
-			exclude_prefixes : Option<Vec<StorageKey>>
-		) -> bool {
-			if exclude_prefixes.is_some() {
-				for exclude_prefix in exclude_prefixes.iter().next().unwrap() {
-					if key_to_check.0.starts_with(&exclude_prefix.0) {
-						// skip all keys that have any of "excluded prefixes"
-						return false
-					}
+	/// Helper function to check a key against lists of prefixes
+	fn is_target_key(
+		&self,
+		key_to_check: StorageKey,
+		include_prefixes : Option<Vec<StorageKey>>,
+		exclude_prefixes : Option<Vec<StorageKey>>
+	) -> bool {
+		if let Some(prefixes_to_exclude) = exclude_prefixes {
+			for exclude_prefix in prefixes_to_exclude {
+				if key_to_check.0.starts_with(&exclude_prefix.0) {
+					// skip all keys that have any of "excluded prefixes"
+					return false
 				}
 			}
-	
-			if include_prefixes.is_some() {
-				for include_prefix in include_prefixes.iter().next().unwrap() {
-					if key_to_check.0.starts_with(&include_prefix.0) {
-						return true
-					}
-				}
-				// skip all keys that do not have any of "included prefixes"
-				return false
-			}
-	
-			// by default process all keys
-			return true
 		}
+
+		if let Some(prefixes_to_include) = include_prefixes {
+			for include_prefix in prefixes_to_include {
+				if key_to_check.0.starts_with(&include_prefix.0) {
+					return true
+				}
+			}
+			// skip all keys that do not have any of "included prefixes"
+			return false
+		}
+
+		// by default process all keys
+		return true
+	}
 }
 
 #[async_trait]

--- a/substrate/client/rpc/src/state/state_full.rs
+++ b/substrate/client/rpc/src/state/state_full.rs
@@ -175,24 +175,24 @@ where
 	)-> std::result::Result<Vec<(StorageKey, Option<StorageData>)>, JsonRpseeError> {
 		// prepare diff
 		let mut storage_diff : Vec<(StorageKey, Option<StorageData>)> = vec![];
-		for key in end_keys {
+		for key in &end_keys {
 			// if a new key is present, add it to the diff
 			if !start_keys.contains(&key) {
 				let new_storage = self.client.storage(end, &key).map_err(client_err)?;
-				storage_diff.push((key, new_storage))
+				storage_diff.push((key.clone(), new_storage))
 			} else {
 				let start_storage_val = self.client.storage(start, &key).map_err(client_err)?;
 				let end_storage_val = self.client.storage(end, &key).map_err(client_err)?;
 
 				if start_storage_val != end_storage_val {
-					storage_diff.push((key, end_storage_val))
+					storage_diff.push((key.clone(), end_storage_val))
 				}
 			}
 		}
 
 		// finally get any keys that have been removed between start_block and end_block
 		for key in start_keys {
-			if storage_diff.iter().position(|r| r.0 == key).is_none() {
+			if end_keys.iter().position(|r| r == &key).is_none() {
 				storage_diff.push((key, None))
 			}
 		}
@@ -265,46 +265,61 @@ where
 		&self,
 		start : Block::Hash,
 		end : Block::Hash,
-		prefixes : Vec<StorageKey>
+		include_prefixes : Option<Vec<StorageKey>>,
+		exclude_prefixes : Option<Vec<StorageKey>>
 	) -> std::result::Result<Vec<(StorageKey, Option<StorageData>)>, JsonRpseeError> {
+		use sc_client_api::KeysIter;
+
 		let mut start_keys = vec![];
 		let mut end_keys = vec![];
+		let start_state = Box::new(self.client.state_at(start).unwrap());
+		let end_state = self.client.state_at(start).unwrap();
 
-		// read all storage keys with given prefixes
-		for prefix in prefixes {
-			let start_keys_of_prefix = self.client.storage_keys(start, None, Some(&prefix)).map_err(client_err)?;
-			let end_keys_of_prefix = self.client.storage_keys(end, None, Some(&prefix)).map_err(client_err)?;
-			start_keys.extend(start_keys_of_prefix);
-			end_keys.extend(end_keys_of_prefix);
+		if let Some(prefixes) = include_prefixes {
+			for prefix in prefixes {
+				let start_keys_of_prefix = KeysIter::new(start_state.clone().inner(), Some(&prefix), None).unwrap();
+				let end_keys_of_prefix = KeysIter::new(end_state.clone(), Some(&prefix), None).unwrap();
+
+				start_keys.extend(start_keys_of_prefix);
+				end_keys.extend(end_keys_of_prefix);
+			}
 		}
+
+		// // read all storage keys with given prefixes
+		// for prefix in prefixes {
+		// 	let start_keys_of_prefix = self.client.storage_keys(start, None, Some(&prefix)).map_err(client_err)?;
+		// 	let end_keys_of_prefix = self.client.storage_keys(end, None, Some(&prefix)).map_err(client_err)?;
+		// 	start_keys.extend(start_keys_of_prefix);
+		// 	end_keys.extend(end_keys_of_prefix);
+		// }
 		
 		self.prepare_storage_diff(start,end, start_keys, end_keys)
 	}
 
-	fn storage_diff_without_prefixes(
-		&self,
-		start : Block::Hash,
-		end : Block::Hash,
-		prefixes : Vec<StorageKey>
-	) -> std::result::Result<Vec<(StorageKey, Option<StorageData>)>, JsonRpseeError> {
-		let start_keys = self.client.storage_keys(start, None, None).map_err(client_err)?;
-		let end_keys = self.client.storage_keys(end, None, None).map_err(client_err)?;
-		let mut start_keys_to_exclude = vec![];
-		let mut end_keys_to_exclude = vec![];
+	// fn storage_diff_without_prefixes(
+	// 	&self,
+	// 	start : Block::Hash,
+	// 	end : Block::Hash,
+	// 	prefixes : Vec<StorageKey>
+	// ) -> std::result::Result<Vec<(StorageKey, Option<StorageData>)>, JsonRpseeError> {
+	// 	let start_keys = self.client.storage_keys(start, None, None).map_err(client_err)?;
+	// 	let end_keys = self.client.storage_keys(end, None, None).map_err(client_err)?;
+	// 	let mut start_keys_to_exclude = vec![];
+	// 	let mut end_keys_to_exclude = vec![];
 
-		// read all storage keys with given prefixes
-		for prefix in prefixes {
-			let start_keys_of_prefix = self.client.storage_keys(start, None, Some(&prefix)).map_err(client_err)?;
-			let end_keys_of_prefix = self.client.storage_keys(end, None, Some(&prefix)).map_err(client_err)?;
-			start_keys_to_exclude.extend(start_keys_of_prefix);
-			end_keys_to_exclude.extend(end_keys_of_prefix);
-		}
+	// 	// read all storage keys with given prefixes
+	// 	for prefix in prefixes {
+	// 		let start_keys_of_prefix = self.client.storage_keys(start, None, Some(&prefix)).map_err(client_err)?;
+	// 		let end_keys_of_prefix = self.client.storage_keys(end, None, Some(&prefix)).map_err(client_err)?;
+	// 		start_keys_to_exclude.extend(start_keys_of_prefix);
+	// 		end_keys_to_exclude.extend(end_keys_of_prefix);
+	// 	}
 
-		let start_keys : Vec<_> = start_keys.filter(|x| !start_keys_to_exclude.contains(&x)).collect();
-		let end_keys : Vec<_> = end_keys.filter(|x| !end_keys_to_exclude.contains(&x)).collect();
+	// 	let start_keys : Vec<_> = start_keys.filter(|x| !start_keys_to_exclude.contains(&x)).collect();
+	// 	let end_keys : Vec<_> = end_keys.filter(|x| !end_keys_to_exclude.contains(&x)).collect();
 		
-		self.prepare_storage_diff(start,end, start_keys, end_keys)
-	}
+	// 	self.prepare_storage_diff(start,end, start_keys, end_keys)
+	// }
 
 	// TODO: This is horribly broken; either remove it, or make it streaming.
 	fn storage_pairs(

--- a/substrate/client/rpc/src/state/state_full.rs
+++ b/substrate/client/rpc/src/state/state_full.rs
@@ -272,13 +272,13 @@ where
 
 		let mut start_keys = vec![];
 		let mut end_keys = vec![];
-		let start_state = Box::new(self.client.state_at(start).unwrap());
+		let start_state = self.client.state_at(start).unwrap();
 		let end_state = self.client.state_at(start).unwrap();
 
 		if let Some(prefixes) = include_prefixes {
 			for prefix in prefixes {
-				let start_keys_of_prefix = KeysIter::new(start_state.clone().inner(), Some(&prefix), None).unwrap();
-				let end_keys_of_prefix = KeysIter::new(end_state.clone(), Some(&prefix), None).unwrap();
+				let start_keys_of_prefix: KeysIter<<Client as CallApiAt<Block>>::StateBackend, Block> = KeysIter::new(start_state.clone(), Some(&prefix), None).unwrap();
+				let end_keys_of_prefix: KeysIter<<Client as CallApiAt<Block>>::StateBackend, Block> = KeysIter::new(end_state.clone(), Some(&prefix), None).unwrap();
 
 				start_keys.extend(start_keys_of_prefix);
 				end_keys.extend(end_keys_of_prefix);

--- a/substrate/client/rpc/src/state/state_full.rs
+++ b/substrate/client/rpc/src/state/state_full.rs
@@ -304,7 +304,7 @@ where
 		start_keys = start_keys.into_iter().filter(|key| self.is_target_key(key.clone(), include_prefixes.clone(), exclude_prefixes.clone())).collect();
 		end_keys = end_keys.into_iter().filter(|key| self.is_target_key(key.clone(), include_prefixes.clone(), exclude_prefixes.clone())).collect();
 
-		self.prepare_storage_diff(start,end, start_keys, end_keys)
+		self.prepare_storage_diff(start, end, start_keys, end_keys)
 	}
 
 	// TODO: This is horribly broken; either remove it, or make it streaming.


### PR DESCRIPTION
This PR introduces a new rpc calla

```rust
/// Returns a storage diff between start block state and end block state of the given keys
#[method(name = "state_getStorageDiffWithPrefixes", aliases = ["state_getStorageDiffPrefixes"], blocking)]
fn storage_diff_with_prefixes(&self, start: Hash, end: Hash, include_prefixes : Vec<StorageKey>, exclude_prefixes : Vec<StorageKey>) -> RpcResult<Vec<(StorageKey, Option<StorageData>)>>;
```

Example usage

`state_getStorageDiffPrefixes`

without any exclusion or inclusion
```bash
curl -sS -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method": "state_getStorageDiffPrefixes", "params": ["0xe098a36c51f17ff40c613a4ad96ad8b440309f918b5537e869526330065ae9e6", "0xcfe37249dd60f77f94752c6c60938612bf437f3d1b6602a38b7cba68ef4bcfc0", null, null]}' http://localhost:9944/
```

with including prefixes
```
curl -sS -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method": "state_getStorageDiffPrefixes", "params": ["0xe098a36c51f17ff40c613a4ad96ad8b440309f918b5537e869526330065ae9e6", "0xcfe37249dd60f77f94752c6c60938612bf437f3d1b6602a38b7cba68ef4bcfc0", ["0x5f3e4907f716ac89b6347d15ececedca422adb579f1dbf4f3886c5cfa3bb8cc4"], null]}' http://localhost:9944/
```

with excluding prefixes

```
curl -sS -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method": "state_getStorageDiffPrefixes", "params": ["0xe098a36c51f17ff40c613a4ad96ad8b440309f918b5537e869526330065ae9e6", "0xcfe37249dd60f77f94752c6c60938612bf437f3d1b6602a38b7cba68ef4bcfc0", null, ["0x5f3e4907f716ac89b6347d15ececedca422adb579f1dbf4f3886c5cfa3bb8cc4"]]}' http://localhost:9944/
```
