### PR TITLE
feat : Insert storage diff to DB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14720,6 +14720,7 @@ name = "sc-client-db"
 version = "0.10.0-dev"
 dependencies = [
  "array-bytes 6.1.0",
+ "bincode",
  "criterion 0.4.0",
  "hash-db",
  "kitchensink-runtime",
@@ -14736,6 +14737,7 @@ dependencies = [
  "sc-client-api",
  "sc-state-db",
  "schnellru",
+ "serde",
  "sp-arithmetic",
  "sp-blockchain",
  "sp-core",
@@ -16229,18 +16231,18 @@ checksum = "f97841a747eef040fcd2e7b3b9a220a7205926e60488e673d9e4926d27772ce5"
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15537,6 +15537,7 @@ dependencies = [
  "assert_matches",
  "env_logger 0.9.3",
  "futures",
+ "hex",
  "jsonrpsee",
  "log",
  "parity-scale-codec",
@@ -15564,6 +15565,7 @@ dependencies = [
  "sp-rpc",
  "sp-runtime",
  "sp-session",
+ "sp-state-machine",
  "sp-statement-store",
  "sp-version",
  "substrate-test-runtime-client",
@@ -15585,6 +15587,7 @@ dependencies = [
  "sp-core",
  "sp-rpc",
  "sp-runtime",
+ "sp-state-machine",
  "sp-version",
  "thiserror",
 ]

--- a/substrate/client/api/src/backend.rs
+++ b/substrate/client/api/src/backend.rs
@@ -586,6 +586,9 @@ pub trait Backend<Block: BlockT>: AuxStore + Send + Sync {
 	/// Returns state backend with post-state of given block.
 	fn state_at(&self, hash: Block::Hash) -> sp_blockchain::Result<Self::State>;
 
+	/// Returns the list of storage update executed by the block
+	fn storage_updates_at(&self, hash: Block::Hash) -> sp_blockchain::Result<(Vec<StorageCollection>, Vec<ChildStorageCollection>)>;
+
 	/// Attempts to revert the chain by `n` blocks. If `revert_finalized` is set it will attempt to
 	/// revert past any finalized block, this is unsafe and can potentially leave the node in an
 	/// inconsistent state. All blocks higher than the best block are also reverted and not counting

--- a/substrate/client/api/src/backend.rs
+++ b/substrate/client/api/src/backend.rs
@@ -435,6 +435,11 @@ pub trait StorageProvider<Block: BlockT, B: Backend<Block>> {
 		start_key: Option<&StorageKey>,
 	) -> sp_blockchain::Result<KeysIter<B::State, Block>>;
 
+	fn storage_updates_at(
+		&self,
+		hash: Block::Hash,
+	) -> sp_blockchain::Result<Vec<(Vec<u8>, Option<Vec<u8>>)>>;
+
 	/// Given a block's `Hash` and a key prefix, returns an iterator over the storage keys and
 	/// values in that block.
 	fn storage_pairs(
@@ -587,7 +592,7 @@ pub trait Backend<Block: BlockT>: AuxStore + Send + Sync {
 	fn state_at(&self, hash: Block::Hash) -> sp_blockchain::Result<Self::State>;
 
 	/// Returns the list of storage update executed by the block
-	fn storage_updates_at(&self, hash: Block::Hash) -> sp_blockchain::Result<(Vec<StorageCollection>, Vec<ChildStorageCollection>)>;
+	fn storage_updates_at(&self, hash: Block::Hash) -> sp_blockchain::Result<(StorageCollection, ChildStorageCollection)>;
 
 	/// Attempts to revert the chain by `n` blocks. If `revert_finalized` is set it will attempt to
 	/// revert past any finalized block, this is unsafe and can potentially leave the node in an

--- a/substrate/client/api/src/backend.rs
+++ b/substrate/client/api/src/backend.rs
@@ -435,10 +435,11 @@ pub trait StorageProvider<Block: BlockT, B: Backend<Block>> {
 		start_key: Option<&StorageKey>,
 	) -> sp_blockchain::Result<KeysIter<B::State, Block>>;
 
+	/// Returns the storage changes between given block and previous block
 	fn storage_updates_at(
 		&self,
 		hash: Block::Hash,
-	) -> sp_blockchain::Result<Vec<(Vec<u8>, Option<Vec<u8>>)>>;
+	) -> sp_blockchain::Result<(StorageCollection, ChildStorageCollection)>;
 
 	/// Given a block's `Hash` and a key prefix, returns an iterator over the storage keys and
 	/// values in that block.

--- a/substrate/client/api/src/in_mem.rs
+++ b/substrate/client/api/src/in_mem.rs
@@ -758,6 +758,10 @@ impl<Block: BlockT> backend::Backend<Block> for Backend<Block> {
 			.ok_or_else(|| sp_blockchain::Error::UnknownBlock(format!("{}", hash)))
 	}
 
+	fn storage_updates_at(&self, hash: Block::Hash) -> sp_blockchain::Result<(Vec<StorageCollection>, Vec<ChildStorageCollection>)> {
+		Ok((Default::default(), Default::default()))
+	}
+
 	fn revert(
 		&self,
 		_n: NumberFor<Block>,

--- a/substrate/client/api/src/in_mem.rs
+++ b/substrate/client/api/src/in_mem.rs
@@ -758,7 +758,7 @@ impl<Block: BlockT> backend::Backend<Block> for Backend<Block> {
 			.ok_or_else(|| sp_blockchain::Error::UnknownBlock(format!("{}", hash)))
 	}
 
-	fn storage_updates_at(&self, hash: Block::Hash) -> sp_blockchain::Result<(Vec<StorageCollection>, Vec<ChildStorageCollection>)> {
+	fn storage_updates_at(&self, hash: Block::Hash) -> sp_blockchain::Result<(StorageCollection, ChildStorageCollection)> {
 		Ok((Default::default(), Default::default()))
 	}
 

--- a/substrate/client/api/src/in_mem.rs
+++ b/substrate/client/api/src/in_mem.rs
@@ -758,7 +758,7 @@ impl<Block: BlockT> backend::Backend<Block> for Backend<Block> {
 			.ok_or_else(|| sp_blockchain::Error::UnknownBlock(format!("{}", hash)))
 	}
 
-	fn storage_updates_at(&self, hash: Block::Hash) -> sp_blockchain::Result<(StorageCollection, ChildStorageCollection)> {
+	fn storage_updates_at(&self, _hash: Block::Hash) -> sp_blockchain::Result<(StorageCollection, ChildStorageCollection)> {
 		Ok((Default::default(), Default::default()))
 	}
 

--- a/substrate/client/db/Cargo.toml
+++ b/substrate/client/db/Cargo.toml
@@ -18,6 +18,8 @@ codec = { package = "parity-scale-codec", version = "3.6.1", features = [
 ] }
 hash-db = "0.16.0"
 kvdb = "0.13.0"
+bincode = "1.3.3"
+serde = "1.0.192"
 kvdb-memorydb = "0.13.0"
 kvdb-rocksdb = { version = "0.19.0", optional = true }
 linked-hash-map = "0.5.4"

--- a/substrate/client/db/src/lib.rs
+++ b/substrate/client/db/src/lib.rs
@@ -1003,6 +1003,13 @@ struct StorageDb<Block: BlockT> {
 	prefix_keys: bool,
 }
 
+// temp :: TODO Implement
+impl<Block: BlockT> std::fmt::Debug for StorageDb<Block> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Ok(())
+    }
+}
+
 impl<Block: BlockT> sp_state_machine::Storage<HashingFor<Block>> for StorageDb<Block> {
 	fn get(&self, key: &Block::Hash, prefix: Prefix) -> Result<Option<DBValue>, String> {
 		if self.prefix_keys {
@@ -2498,7 +2505,7 @@ impl<Block: BlockT> sc_client_api::backend::Backend<Block> for Backend<Block> {
 					// 		self.shared_trie_cache.as_ref().map(|c| c.local_cache()),
 					// 	)
 					// 	.build();
-					let state = self.storage.state_db.get("block/storage_updates".into(), &self.storage);
+					let state = self.storage.state_db.get(&hdr.state_root.encode(), &Arc::try_unwrap(self.storage).unwrap());
 					//Ok((db_state.storage().storage_updates, db_state.storage().child_storage_updates))
 				} else {
 					Err(sp_blockchain::Error::UnknownBlock(format!(

--- a/substrate/client/db/src/lib.rs
+++ b/substrate/client/db/src/lib.rs
@@ -1575,13 +1575,13 @@ impl<Block: BlockT> Backend<Block> {
 
 				// add the storage updates to the changeset
 				let storage_updates_encoded = serialize(&operation.storage_updates.clone()).unwrap();
-				let mut storage_updates_key = hash.encode();
-				storage_updates_key.extend_from_slice(STORAGE_UPDATE_PREFIX.as_bytes());
+				let mut storage_updates_key = STORAGE_UPDATE_PREFIX.as_bytes().to_vec();
+				storage_updates_key.extend_from_slice(&hash.encode());
 				changeset.inserted.push((storage_updates_key, storage_updates_encoded.clone()));
 
 				let child_storage_updates_encoded = serialize(&operation.child_storage_updates.clone()).unwrap();
-				let mut child_storage_updates_key = hash.encode();
-				child_storage_updates_key.extend_from_slice(CHILD_STORAGE_UPDATE_PREFIX.as_bytes());
+				let mut child_storage_updates_key = CHILD_STORAGE_UPDATE_PREFIX.as_bytes().to_vec();
+				child_storage_updates_key.extend_from_slice(&hash.encode());
 				changeset.inserted.push((child_storage_updates_key, child_storage_updates_encoded));
 
 				self.state_usage.tally_writes_nodes(ops, bytes);
@@ -2497,8 +2497,8 @@ impl<Block: BlockT> sc_client_api::backend::Backend<Block> for Backend<Block> {
 				if let Ok(()) =
 					self.storage.state_db.pin(&hash, hdr.number.saturated_into::<u64>(), hint)
 				{
-					let mut storage_updates_key = hash.encode();
-					storage_updates_key.extend_from_slice(STORAGE_UPDATE_PREFIX.as_bytes());					
+					let mut storage_updates_key = STORAGE_UPDATE_PREFIX.as_bytes().to_vec();
+					storage_updates_key.extend_from_slice(&hash.encode());					
 					let storage_collection_raw = self.storage.db.get(columns::STATE, &storage_updates_key);
 
 					let storage_collection : StorageCollection = if let Some(storage_collection) = storage_collection_raw {
@@ -2507,8 +2507,8 @@ impl<Block: BlockT> sc_client_api::backend::Backend<Block> for Backend<Block> {
 						Default::default()
 					};
 
-					let mut child_storage_updates_key = hash.encode();
-					child_storage_updates_key.extend_from_slice(CHILD_STORAGE_UPDATE_PREFIX.as_bytes());
+					let mut child_storage_updates_key = CHILD_STORAGE_UPDATE_PREFIX.as_bytes().to_vec();
+					child_storage_updates_key.extend_from_slice(&hash.encode());
 					let child_storage_collection_raw = self.storage.db.get(columns::STATE, &child_storage_updates_key);
 
 					let child_storage_collection : ChildStorageCollection = if let Some(child_storage_collection) = child_storage_collection_raw {

--- a/substrate/client/rpc-api/Cargo.toml
+++ b/substrate/client/rpc-api/Cargo.toml
@@ -23,6 +23,7 @@ sc-mixnet = { path = "../mixnet" }
 sc-transaction-pool-api = { path = "../transaction-pool/api" }
 sp-core = { path = "../../primitives/core" }
 sp-rpc = { path = "../../primitives/rpc" }
+sp-state-machine = { path = "../../primitives/state-machine" }
 sp-runtime = { path = "../../primitives/runtime" }
 sp-version = { path = "../../primitives/version" }
 jsonrpsee = { version = "0.16.2", features = ["server", "client-core", "macros"] }

--- a/substrate/client/rpc-api/src/state/mod.rs
+++ b/substrate/client/rpc-api/src/state/mod.rs
@@ -45,7 +45,7 @@ pub trait StateApi<Hash> {
 
 	/// Returns a storage diff between given block and previous block
 	#[method(name = "state_getStorageDiff", aliases = ["state_getStorageDiffAt"], blocking)]
-	fn storage_diff(&self, block: Hash) -> RpcResult<(StorageCollection, ChildStorageCollection)>;
+	fn storage_diff(&self, block: Hash, prefixes: Option<Vec<StorageKey>>) -> RpcResult<(StorageCollection, ChildStorageCollection)>;
 
 	/// Returns the keys with prefix, leave empty to get all the keys
 	#[method(name = "state_getPairs", blocking)]

--- a/substrate/client/rpc-api/src/state/mod.rs
+++ b/substrate/client/rpc-api/src/state/mod.rs
@@ -42,6 +42,14 @@ pub trait StateApi<Hash> {
 	#[deprecated(since = "2.0.0", note = "Please use `getKeysPaged` with proper paging support")]
 	fn storage_keys(&self, prefix: StorageKey, hash: Option<Hash>) -> RpcResult<Vec<StorageKey>>;
 
+	/// Returns a storage diff between start block state and end block state
+	#[method(name = "state_getStorageDiff", aliases = ["state_getStorageDiffAt"], blocking)]
+	fn storage_diff(&self, start: Hash, end: Hash) -> RpcResult<Vec<(Vec<u8>, Option<Vec<u8>>)>>;
+
+	/// Returns a storage diff between start block state and end block state with option to include or exclude prefixes
+	#[method(name = "state_getStorageDiffWithPrefixes", aliases = ["state_getStorageDiffPrefixes"], blocking)]
+	fn storage_diff_with_prefixes(&self, start: Hash, end: Hash, include_prefixes : Option<Vec<StorageKey>>, exclude_prefixes : Option<Vec<StorageKey>>) -> RpcResult<Vec<(StorageKey, Option<StorageData>)>>;
+	
 	/// Returns the keys with prefix, leave empty to get all the keys
 	#[method(name = "state_getPairs", blocking)]
 	fn storage_pairs(

--- a/substrate/client/rpc-api/src/state/mod.rs
+++ b/substrate/client/rpc-api/src/state/mod.rs
@@ -45,7 +45,7 @@ pub trait StateApi<Hash> {
 
 	/// Returns a storage diff between given block and previous block
 	#[method(name = "state_getStorageDiff", aliases = ["state_getStorageDiffAt"], blocking)]
-	fn storage_diff(&self, block: Hash, prefixes: Option<Vec<StorageKey>>) -> RpcResult<(StorageCollection, ChildStorageCollection)>;
+	fn storage_diff(&self, block: Hash, included_prefixes: Option<Vec<StorageKey>>, excluded_prefixes: Option<Vec<StorageKey>>) -> RpcResult<(StorageCollection, ChildStorageCollection)>;
 
 	/// Returns the keys with prefix, leave empty to get all the keys
 	#[method(name = "state_getPairs", blocking)]

--- a/substrate/client/rpc-api/src/state/mod.rs
+++ b/substrate/client/rpc-api/src/state/mod.rs
@@ -45,7 +45,7 @@ pub trait StateApi<Hash> {
 
 	/// Returns a storage diff between given block and previous block
 	#[method(name = "state_getStorageDiff", aliases = ["state_getStorageDiffAt"], blocking)]
-	fn storage_diff(&self, block: Hash, included_prefixes: Option<Vec<StorageKey>>, excluded_prefixes: Option<Vec<StorageKey>>) -> RpcResult<(StorageCollection, ChildStorageCollection)>;
+	fn storage_diff(&self, block: Hash, included_prefixes: Option<Vec<StorageKey>>, excluded_prefixes: Option<Vec<StorageKey>>, include_modified_child_tries: Option<bool>) -> RpcResult<(StorageCollection, Option<ChildStorageCollection>)>;
 
 	/// Returns the keys with prefix, leave empty to get all the keys
 	#[method(name = "state_getPairs", blocking)]

--- a/substrate/client/rpc-api/src/state/mod.rs
+++ b/substrate/client/rpc-api/src/state/mod.rs
@@ -24,6 +24,7 @@ use sp_core::{
 	Bytes,
 };
 use sp_version::RuntimeVersion;
+use sp_state_machine::{ChildStorageCollection, StorageCollection};
 
 pub mod error;
 pub mod helpers;
@@ -42,14 +43,10 @@ pub trait StateApi<Hash> {
 	#[deprecated(since = "2.0.0", note = "Please use `getKeysPaged` with proper paging support")]
 	fn storage_keys(&self, prefix: StorageKey, hash: Option<Hash>) -> RpcResult<Vec<StorageKey>>;
 
-	/// Returns a storage diff between start block state and end block state
+	/// Returns a storage diff between given block and previous block
 	#[method(name = "state_getStorageDiff", aliases = ["state_getStorageDiffAt"], blocking)]
-	fn storage_diff(&self, start: Hash, end: Hash) -> RpcResult<Vec<(Vec<u8>, Option<Vec<u8>>)>>;
+	fn storage_diff(&self, block: Hash) -> RpcResult<(StorageCollection, ChildStorageCollection)>;
 
-	/// Returns a storage diff between start block state and end block state with option to include or exclude prefixes
-	#[method(name = "state_getStorageDiffWithPrefixes", aliases = ["state_getStorageDiffPrefixes"], blocking)]
-	fn storage_diff_with_prefixes(&self, start: Hash, end: Hash, include_prefixes : Option<Vec<StorageKey>>, exclude_prefixes : Option<Vec<StorageKey>>) -> RpcResult<Vec<(StorageKey, Option<StorageData>)>>;
-	
 	/// Returns the keys with prefix, leave empty to get all the keys
 	#[method(name = "state_getPairs", blocking)]
 	fn storage_pairs(

--- a/substrate/client/rpc/Cargo.toml
+++ b/substrate/client/rpc/Cargo.toml
@@ -37,7 +37,8 @@ sp-runtime = { path = "../../primitives/runtime" }
 sp-session = { path = "../../primitives/session" }
 sp-version = { path = "../../primitives/version" }
 sp-statement-store = { path = "../../primitives/statement-store" }
-
+sp-state-machine = { path = "../../primitives/state-machine" }
+hex = "0.4"
 tokio = "1.22.0"
 
 [dev-dependencies]

--- a/substrate/client/rpc/src/state/mod.rs
+++ b/substrate/client/rpc/src/state/mod.rs
@@ -103,6 +103,7 @@ where
 	fn storage_diff(
 		&self,
 		block: Block::Hash,
+		prefixes: Option<Vec<StorageKey>>
 	) -> Result<(StorageCollection, ChildStorageCollection), Error>;
 
 	/// Returns the hash of a storage entry at a block's state.
@@ -264,8 +265,9 @@ where
 	fn storage_diff(
 		&self,
 		block: Block::Hash,
+		prefixes: Option<Vec<StorageKey>>
 	) -> RpcResult<(StorageCollection, ChildStorageCollection)> {
-		self.backend.storage_diff(block).map_err(Into::into)
+		self.backend.storage_diff(block, prefixes).map_err(Into::into)
 	}
 
 	fn storage_hash(

--- a/substrate/client/rpc/src/state/mod.rs
+++ b/substrate/client/rpc/src/state/mod.rs
@@ -50,6 +50,7 @@ use sc_client_api::{
 };
 pub use sc_rpc_api::{child_state::*, state::*};
 use sp_blockchain::{HeaderBackend, HeaderMetadata};
+use sp_state_machine::{StorageCollection, ChildStorageCollection};
 
 const STORAGE_KEYS_PAGED_MAX_COUNT: u32 = 1000;
 
@@ -98,21 +99,11 @@ where
 		key: StorageKey,
 	) -> Result<Option<StorageData>, Error>;
 
-	/// Returns a storage diff between start block and end block
+	/// Returns a storage diff between given block and previous block
 	fn storage_diff(
 		&self,
-		start: Block::Hash,
-		end: Block::Hash,
-	) -> RpcResult<Vec<(Vec<u8>, Option<Vec<u8>>)>>;
-
-	/// Returns a storage diff between start block and end block with an option to include or exclude prefixes
-	fn storage_diff_with_prefixes(
-		&self,
-		start: Block::Hash,
-		end: Block::Hash,
-		include_prefixes : Option<Vec<StorageKey>>,
-		exclude_prefixes : Option<Vec<StorageKey>>
-	) -> RpcResult<Vec<(StorageKey, Option<StorageData>)>>;
+		block: Block::Hash,
+	) -> Result<(StorageCollection, ChildStorageCollection), Error>;
 
 	/// Returns the hash of a storage entry at a block's state.
 	fn storage_hash(
@@ -272,20 +263,9 @@ where
 
 	fn storage_diff(
 		&self,
-		start: Block::Hash,
-		end: Block::Hash,
-	) -> RpcResult<Vec<(Vec<u8>, Option<Vec<u8>>)>> {
-		self.backend.storage_diff(start, end).map_err(Into::into)
-	}
-
-	fn storage_diff_with_prefixes(
-		&self,
-		start: Block::Hash,
-		end: Block::Hash,
-		include_prefixes : Option<Vec<StorageKey>>,
-		exclude_prefixes : Option<Vec<StorageKey>>
-	) -> RpcResult<Vec<(StorageKey, Option<StorageData>)>> {
-		self.backend.storage_diff_with_prefixes(start, end, include_prefixes, exclude_prefixes).map_err(Into::into)
+		block: Block::Hash,
+	) -> RpcResult<(StorageCollection, ChildStorageCollection)> {
+		self.backend.storage_diff(block).map_err(Into::into)
 	}
 
 	fn storage_hash(

--- a/substrate/client/rpc/src/state/mod.rs
+++ b/substrate/client/rpc/src/state/mod.rs
@@ -103,7 +103,8 @@ where
 	fn storage_diff(
 		&self,
 		block: Block::Hash,
-		prefixes: Option<Vec<StorageKey>>
+		included_prefixes: Option<Vec<StorageKey>>,
+		excluded_prefixes: Option<Vec<StorageKey>>,
 	) -> Result<(StorageCollection, ChildStorageCollection), Error>;
 
 	/// Returns the hash of a storage entry at a block's state.
@@ -265,9 +266,10 @@ where
 	fn storage_diff(
 		&self,
 		block: Block::Hash,
-		prefixes: Option<Vec<StorageKey>>
+		included_prefixes: Option<Vec<StorageKey>>,
+		excluded_prefixes: Option<Vec<StorageKey>>,
 	) -> RpcResult<(StorageCollection, ChildStorageCollection)> {
-		self.backend.storage_diff(block, prefixes).map_err(Into::into)
+		self.backend.storage_diff(block, included_prefixes, excluded_prefixes).map_err(Into::into)
 	}
 
 	fn storage_hash(

--- a/substrate/client/rpc/src/state/mod.rs
+++ b/substrate/client/rpc/src/state/mod.rs
@@ -98,6 +98,22 @@ where
 		key: StorageKey,
 	) -> Result<Option<StorageData>, Error>;
 
+	/// Returns a storage diff between start block and end block
+	fn storage_diff(
+		&self,
+		start: Block::Hash,
+		end: Block::Hash,
+	) -> RpcResult<Vec<(Vec<u8>, Option<Vec<u8>>)>>;
+
+	/// Returns a storage diff between start block and end block with an option to include or exclude prefixes
+	fn storage_diff_with_prefixes(
+		&self,
+		start: Block::Hash,
+		end: Block::Hash,
+		include_prefixes : Option<Vec<StorageKey>>,
+		exclude_prefixes : Option<Vec<StorageKey>>
+	) -> RpcResult<Vec<(StorageKey, Option<StorageData>)>>;
+
 	/// Returns the hash of a storage entry at a block's state.
 	fn storage_hash(
 		&self,
@@ -252,6 +268,24 @@ where
 		block: Option<Block::Hash>,
 	) -> RpcResult<Option<StorageData>> {
 		self.backend.storage(block, key).map_err(Into::into)
+	}
+
+	fn storage_diff(
+		&self,
+		start: Block::Hash,
+		end: Block::Hash,
+	) -> RpcResult<Vec<(Vec<u8>, Option<Vec<u8>>)>> {
+		self.backend.storage_diff(start, end).map_err(Into::into)
+	}
+
+	fn storage_diff_with_prefixes(
+		&self,
+		start: Block::Hash,
+		end: Block::Hash,
+		include_prefixes : Option<Vec<StorageKey>>,
+		exclude_prefixes : Option<Vec<StorageKey>>
+	) -> RpcResult<Vec<(StorageKey, Option<StorageData>)>> {
+		self.backend.storage_diff_with_prefixes(start, end, include_prefixes, exclude_prefixes).map_err(Into::into)
 	}
 
 	fn storage_hash(

--- a/substrate/client/rpc/src/state/mod.rs
+++ b/substrate/client/rpc/src/state/mod.rs
@@ -105,7 +105,8 @@ where
 		block: Block::Hash,
 		included_prefixes: Option<Vec<StorageKey>>,
 		excluded_prefixes: Option<Vec<StorageKey>>,
-	) -> Result<(StorageCollection, ChildStorageCollection), Error>;
+		include_modified_child_tries: bool,
+	) -> Result<(StorageCollection, Option<ChildStorageCollection>), Error>;
 
 	/// Returns the hash of a storage entry at a block's state.
 	fn storage_hash(
@@ -268,8 +269,9 @@ where
 		block: Block::Hash,
 		included_prefixes: Option<Vec<StorageKey>>,
 		excluded_prefixes: Option<Vec<StorageKey>>,
-	) -> RpcResult<(StorageCollection, ChildStorageCollection)> {
-		self.backend.storage_diff(block, included_prefixes, excluded_prefixes).map_err(Into::into)
+		include_modified_child_tries: Option<bool>,
+	) -> RpcResult<(StorageCollection, Option<ChildStorageCollection>)> {
+		self.backend.storage_diff(block, included_prefixes, excluded_prefixes, include_modified_child_tries.is_some()).map_err(Into::into)
 	}
 
 	fn storage_hash(

--- a/substrate/client/rpc/src/state/state_full.rs
+++ b/substrate/client/rpc/src/state/state_full.rs
@@ -254,13 +254,12 @@ where
 		excluded_prefixes: Option<Vec<StorageKey>>,
 		include_modified_child_tries: bool,
 	) -> std::result::Result<(StorageCollection, Option<ChildStorageCollection>), Error> {
-		let (mut modified_keys, mut child_storage_collection) = self.client.storage_updates_at(block).map_err(client_err)?;
+		let (mut modified_keys, child_storage_collection) = self.client.storage_updates_at(block).map_err(client_err)?;
 
 		// retain only required prefixes
 		modified_keys.retain(|key| self.is_target_key(sc_client_api::StorageKey(key.0.clone()), included_prefixes.clone(), excluded_prefixes.clone()));
 		
 		let modified_child_keys = if include_modified_child_tries {
-			child_storage_collection.retain(|key| self.is_target_key(sc_client_api::StorageKey(key.0.clone()), included_prefixes.clone(), excluded_prefixes.clone()));
 			Some(child_storage_collection) 
 		}
 		else {

--- a/substrate/client/rpc/src/state/state_full.rs
+++ b/substrate/client/rpc/src/state/state_full.rs
@@ -252,14 +252,22 @@ where
 		block : Block::Hash,
 		included_prefixes: Option<Vec<StorageKey>>,
 		excluded_prefixes: Option<Vec<StorageKey>>,
-	) -> std::result::Result<(StorageCollection, ChildStorageCollection), Error> {
-		let (mut storage_collection, mut child_storage_collection) = self.client.storage_updates_at(block).map_err(client_err)?;
+		include_modified_child_tries: bool,
+	) -> std::result::Result<(StorageCollection, Option<ChildStorageCollection>), Error> {
+		let (mut modified_keys, mut child_storage_collection) = self.client.storage_updates_at(block).map_err(client_err)?;
 
 		// retain only required prefixes
-		storage_collection.retain(|key| self.is_target_key(sc_client_api::StorageKey(key.0.clone()), included_prefixes.clone(), excluded_prefixes.clone()));
-		child_storage_collection.retain(|key| self.is_target_key(sc_client_api::StorageKey(key.0.clone()), included_prefixes.clone(), excluded_prefixes.clone()));
+		modified_keys.retain(|key| self.is_target_key(sc_client_api::StorageKey(key.0.clone()), included_prefixes.clone(), excluded_prefixes.clone()));
+		
+		let modified_child_keys = if include_modified_child_tries {
+			child_storage_collection.retain(|key| self.is_target_key(sc_client_api::StorageKey(key.0.clone()), included_prefixes.clone(), excluded_prefixes.clone()));
+			Some(child_storage_collection) 
+		}
+		else {
+			None
+		};
 
-		Ok((storage_collection, child_storage_collection))
+		Ok((modified_keys, modified_child_keys))
 	}
 
 	// TODO: This is horribly broken; either remove it, or make it streaming.

--- a/substrate/client/rpc/src/state/state_full.rs
+++ b/substrate/client/rpc/src/state/state_full.rs
@@ -170,9 +170,9 @@ where
 	/// Helper function to check a key against lists of prefixes
 	fn is_target_key(
 		&self,
-		key_to_check: StorageKey,
-		include_prefixes : Option<Vec<StorageKey>>,
-		exclude_prefixes : Option<Vec<StorageKey>>
+		key_to_check: &StorageKey,
+		include_prefixes : &Option<Vec<StorageKey>>,
+		exclude_prefixes : &Option<Vec<StorageKey>>
 	) -> bool {
 		if let Some(prefixes_to_exclude) = exclude_prefixes {
 			for exclude_prefix in prefixes_to_exclude {
@@ -257,16 +257,9 @@ where
 		let (mut modified_keys, child_storage_collection) = self.client.storage_updates_at(block).map_err(client_err)?;
 
 		// retain only required prefixes
-		modified_keys.retain(|key| self.is_target_key(sc_client_api::StorageKey(key.0.clone()), included_prefixes.clone(), excluded_prefixes.clone()));
+		modified_keys.retain(|key| self.is_target_key(&sc_client_api::StorageKey(key.0.clone()), &included_prefixes, &excluded_prefixes));
 		
-		let modified_child_keys = if include_modified_child_tries {
-			Some(child_storage_collection) 
-		}
-		else {
-			None
-		};
-
-		Ok((modified_keys, modified_child_keys))
+		Ok((modified_keys, include_modified_child_tries.then_some(child_storage_collection)))
 	}
 
 	// TODO: This is horribly broken; either remove it, or make it streaming.

--- a/substrate/client/service/src/client/client.rs
+++ b/substrate/client/service/src/client/client.rs
@@ -1514,10 +1514,9 @@ where
 	fn storage_updates_at(
 		&self,
 		hash: Block::Hash,
-	) -> sp_blockchain::Result<Vec<(Vec<u8>, Option<Vec<u8>>)>> {
+	) -> sp_blockchain::Result<(StorageCollection, ChildStorageCollection)> {
 		Ok(self
 			.backend.storage_updates_at(hash)?
-			.0
 			)
 	}
 

--- a/substrate/client/service/src/client/client.rs
+++ b/substrate/client/service/src/client/client.rs
@@ -1511,6 +1511,16 @@ where
 			.map(StorageData))
 	}
 
+	fn storage_updates_at(
+		&self,
+		hash: Block::Hash,
+	) -> sp_blockchain::Result<Vec<(Vec<u8>, Option<Vec<u8>>)>> {
+		Ok(self
+			.backend.storage_updates_at(hash)?
+			.0
+			)
+	}
+
 	fn storage_hash(
 		&self,
 		hash: <Block as BlockT>::Hash,


### PR DESCRIPTION
Insert storage changes and child storage changes to DB, these values are then used to return the storage diff for blocks from `storage_diff` endpoint.

