### PR TITLE
fix: convert to serialisable types

### DIFF
--- a/substrate/client/rpc-api/src/state/mod.rs
+++ b/substrate/client/rpc-api/src/state/mod.rs
@@ -20,11 +20,10 @@
 
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use sp_core::{
-	storage::{StorageChangeSet, StorageData, StorageKey},
+	storage::{StorageChangeSet, StorageData, StorageKey, ChildStorageCollection, StorageCollection},
 	Bytes,
 };
 use sp_version::RuntimeVersion;
-use sp_state_machine::{ChildStorageCollection, StorageCollection};
 
 pub mod error;
 pub mod helpers;

--- a/substrate/client/rpc/src/state/mod.rs
+++ b/substrate/client/rpc/src/state/mod.rs
@@ -35,7 +35,7 @@ use jsonrpsee::{
 
 use sc_rpc_api::DenyUnsafe;
 use sp_core::{
-	storage::{PrefixedStorageKey, StorageChangeSet, StorageData, StorageKey},
+	storage::{PrefixedStorageKey, StorageChangeSet, StorageData, StorageKey, StorageCollection, ChildStorageCollection},
 	Bytes,
 };
 use sp_runtime::traits::Block as BlockT;
@@ -50,7 +50,6 @@ use sc_client_api::{
 };
 pub use sc_rpc_api::{child_state::*, state::*};
 use sp_blockchain::{HeaderBackend, HeaderMetadata};
-use sp_state_machine::{StorageCollection, ChildStorageCollection};
 
 const STORAGE_KEYS_PAGED_MAX_COUNT: u32 = 1000;
 

--- a/substrate/primitives/storage/src/lib.rs
+++ b/substrate/primitives/storage/src/lib.rs
@@ -149,6 +149,12 @@ pub struct StorageData(
 	#[cfg_attr(feature = "serde", serde(with = "impl_serde::serialize"))] pub Vec<u8>,
 );
 
+/// Storage Collection
+pub type StorageCollection = Vec<(StorageKey, Option<StorageData>)>;
+
+/// Child Storage Collection
+pub type ChildStorageCollection = Vec<(StorageKey, StorageCollection)>;
+
 /// Map of data to use in a storage, it is a collection of
 /// byte key and values.
 #[cfg(feature = "std")]


### PR DESCRIPTION
Follow up to https://github.com/traittech/polkadot-sdk/pull/5

Use serialisable type for better readable response in RPC